### PR TITLE
2models with negative feedback, looks to work

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ import tensorflow as tf
 from model import Model
 from plot import Plot
 from game import Game
+import matplotlib.pyplot as plt
+
 
 #os.environ['CUDA_VISIBLE_DEVICES'] = ''
 #os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -25,12 +27,21 @@ class Main:
         self.X = tf.placeholder(tf.float32, [None, self.feature_length])
         self.Y = tf.placeholder(tf.float32, [None, self.label_length])
         self.model = Model(self.X, self.Y)
+        self.model2 = Model(self.X, self.Y)
         self.global_step = 0
+        self.winRatio = np.zeros(100000)
 
         self.training_data_x = np.empty((0, self.feature_length))
         self.training_data_y = np.empty((0, self.label_length))
+        
+        
+        self.training_data_x_loss = np.empty((0, self.feature_length))
+        self.training_data_y_loss = np.empty((0, self.label_length))
+        
         self.test_training_data_x = np.empty((0, self.feature_length))
         self.test_training_data_y = np.empty((0, self.label_length))
+        
+        self.Count1Win = 0
 
     def add_training_data(self, features, labels, add_to_test_data):
         self.training_data_x = np.concatenate((self.training_data_x, features), axis=0)
@@ -39,6 +50,12 @@ class Main:
         if add_to_test_data:
             self.test_training_data_x = np.concatenate((self.test_training_data_x, features), axis=0)
             self.test_training_data_y = np.concatenate((self.test_training_data_y, labels), axis=0)
+            
+    def add_training_data_loss(self, features, labels, add_to_test_data):
+        self.training_data_x_loss = np.concatenate((self.training_data_x_loss, features), axis=0)
+        self.training_data_y_loss = np.concatenate((self.training_data_y_loss, labels), axis=0)
+
+        return
 
 
     def get_data_for_prediction(self, user, opponent):
@@ -164,7 +181,11 @@ class Main:
                         data = self.get_data_for_prediction(game.opponent, game.user)
                         
                     #print('features view: {}'.format(data))
-                    predicted_actions = sess.run(self.model.prediction, { self.X: data })[0]
+                    if game.players_turn is False:
+                        predicted_actions = sess.run(self.model.prediction, { self.X: data })[0]
+                    else:
+                        predicted_actions = sess.run(self.model2.prediction, { self.X: data })[0]
+                        
                     predicted_actions = self.sigmoid(predicted_actions)
                     MaxPred = np.sum(predicted_actions)
                     ProbPred = predicted_actions / MaxPred
@@ -189,9 +210,15 @@ class Main:
                         #record winning data
                         if did_player_1_win:
                             self.add_training_data(game.player_training_data.feature, game.player_training_data.label, True)
+                            self.add_training_data_loss(game.opponent_training_data.feature, 1-game.opponent_training_data.label, True)
+                            Play1 = True
+                            self.Count1Win += 1
                             #self.add_training_data(game.opponent_training_data.feature, 1 - game.opponent_training_data.label, False)
                         else:
                             self.add_training_data(game.opponent_training_data.feature, game.opponent_training_data.label, True)
+                            self.add_training_data_loss(game.player_training_data.feature, 1-game.player_training_data.label, True)
+                            
+                            Play1 = False
                             #self.add_training_data(game.player_training_data.feature, 1 - game.player_training_data.label, False)
 
                         number_of_games_played += 1
@@ -210,14 +237,42 @@ class Main:
                     for _ in range(1):
                         
                         training_data_size = np.size(self.training_data_x, 0)
-                        print(training_data_size)
-                        random_range = np.arange(training_data_size)
-                        np.random.shuffle(random_range)
+                        training_data_loss_size = np.size(self.training_data_x_loss, 0)
+                        self.training_data_y_loss *= 0.33
+                        
+                        # By taking out the negative on one then it wins more often
+                        # worked when all set to 0.25 or 1, but not 0
+                        # Still a slight bias for going first you win but player1 doesnt converge to attack atttack attack
+                        
+                        
+                        
+                        #print(self.training_data_x)
+                        #print(self.training_data_y)
+                        #print(self.training_data_x_loss)
+                        #print(self.training_data_y_loss)
+                        
+                        #hi
+                        #random_range = np.arange(training_data_size)
+                        #np.random.shuffle(random_range)
 
                         for i in range(training_data_size):
-                            random_index = random_range[i]
-                            _, loss = sess.run(self.model.optimize, { self.X: np.reshape(self.training_data_x[random_index], (-1, self.feature_length)), self.Y: np.reshape(self.training_data_y[random_index],(-1, 4))})
-                        #_, loss = sess.run(model.optimize, { X: self.training_data_x, Y: self.training_data_y })
+                            random_index = i #random_range[i]
+                            if Play1:
+                                _, loss = sess.run(self.model.optimize, { self.X: np.reshape(self.training_data_x[random_index], (-1, self.feature_length)), self.Y: np.reshape(self.training_data_y[random_index],(-1, 4))})
+                            else:
+                                _, loss = sess.run(self.model2.optimize, { self.X: np.reshape(self.training_data_x[random_index], (-1,    self.feature_length)), self.Y: np.reshape(self.training_data_y[random_index],(-1, 4))})
+                                
+                                                    #_, loss = sess.run(model.optimize, { X: self.training_data_x, Y: self.training_data_y })
+                        
+                        #random_range_loss = np.arange(training_data_size)
+                        #np.random.shuffle(random_range_loss)
+                        for i in range(training_data_loss_size):
+                            random_index_loss = i #random_range_loss[i]
+                            if Play1:
+                                _, loss = sess.run(self.model2.optimize, { self.X: np.reshape(self.training_data_x_loss[random_index_loss], (-1, self.feature_length)), self.Y: np.reshape(self.training_data_y_loss[random_index_loss],(-1, 4))})
+                            else:
+                                _, loss = sess.run(self.model.optimize, { self.X: np.reshape(self.training_data_x_loss[random_index_loss], (-1, self.feature_length)), self.Y: np.reshape(self.training_data_y_loss[random_index_loss],(-1, 4))})
+                
                         self.global_step += 1
 
                     current_accuracy = sess.run(self.model.error, { self.X: self.test_training_data_x, self.Y: self.test_training_data_y })
@@ -229,7 +284,8 @@ class Main:
                     #self.test_training_data_x = np.empty((0, self.feature_length))
                     #self.test_training_data_y = np.empty((0, self.label_length))
 
-
+                    
+                    self.winRatio[self.global_step] = self.Count1Win / self.global_step
                     #user_input = input('paused')
                     #print('Saving...')
                     #saver.save(sess, self.checkpoint)
@@ -246,9 +302,17 @@ class Main:
                     # plt.ylabel('Inputs')
                     # plt.show()
                     # plt.close()
-                    
-                    self.cost_plot.save_sub_plot(self.accuracy_plot,
-                    "data/Charts/{} and {}.png".format(self.cost_plot.y_label, self.accuracy_plot.y_label))
+                    if self.global_step%50 ==0:
+                        self.cost_plot.save_sub_plot(self.accuracy_plot,
+                        "data/Charts/{} and {}.png".format(self.cost_plot.y_label, self.accuracy_plot.y_label))
+                        
+                        plt.figure()
+                        lin = np.zeros(self.global_step)
+                        lin += 0.5
+                        plt.plot(self.winRatio[0:self.global_step])
+                        plt.plot(lin)
+                        plt.savefig('data/Charts/winratio.png')
+                        plt.close()
 
                     # user_input = input('Continue (y/n)')
                     # if user_input == 'n':

--- a/model.py
+++ b/model.py
@@ -17,27 +17,36 @@ class Model:
     def prediction(self):
         feature_size = 6
         label_size = 4
-        layer_1_size = 40
+        layer_1_size = 10
+        layer_2_size = 8
 
         with tf.variable_scope('layer_1') as scope:
             layer_1_weights = tf.Variable(tf.random_uniform(shape=[feature_size, layer_1_size], minval = 0.001, maxval = 0.01), name="weights")
             #layer_1_weights = tf.Variable(tf.constant(0.0, shape=[feature_size, layer_1_size]), name="weights")
             layer_1_biases = tf.Variable(tf.constant(0.001, shape = [layer_1_size]), name = "biases")
             layer_1 = tf.nn.relu(tf.matmul(self.feature, layer_1_weights) + layer_1_biases)
+            
+        with tf.variable_scope('layer_2') as scope:
+            layer_2_weights = tf.Variable(tf.random_uniform(shape=[layer_1_size, layer_2_size], minval = 0.001, maxval = 0.01), name="weights")
+            #layer_1_weights = tf.Variable(tf.constant(0.0, shape=[feature_size, layer_1_size]), name="weights")
+            layer_2_biases = tf.Variable(tf.constant(0.001, shape = [layer_2_size]), name = "biases")
+            layer_2 = tf.nn.relu(tf.matmul(layer_1, layer_2_weights) + layer_2_biases)
 
         with tf.variable_scope('layer_output') as scope:
-            output_weights = tf.Variable(tf.random_uniform(shape = [layer_1_size, label_size], minval = 0.001, maxval = 0.01), name = "weights")
+            output_weights = tf.Variable(tf.random_uniform(shape = [layer_2_size, label_size], minval = 0.001, maxval = 0.01), name = "weights")
             output_biases = tf.Variable(tf.constant(0.001, shape = [label_size]), name = "biases")
-            output = tf.matmul(layer_1, output_weights) + output_biases
+            output = tf.matmul(layer_2, output_weights) + output_biases
+            
 
         return output
 
     @lazy_property
     def optimize(self):
-        learning_rate = 0.3
+        learning_rate = 0.05
         cost = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(logits=self.prediction, labels=self.label))
+        #cost = tf.losses.mean_squared_error(self.prediction, self.label)
         #return tf.train.AdamOptimizer(learning_rate = learning_rate).minimize(cost), cost
-        return tf.train.GradientDescentOptimizer(learning_rate = learning_rate).minimize(cost), cost
+        return tf.train.AdamOptimizer(learning_rate = learning_rate).minimize(cost), cost
 
     @lazy_property
     def error(self):


### PR DESCRIPTION
Pretty hacked so excuse it


1. Two models for the AI are implemented 
2. Added a negative feedback (not what to do) when AI gets it wrong. got it working now so that player one doesn't converge on to attack, attack attack. Have a plot to show the win ratio.
- It now hovers around 50:50, as it should if its learning... So its promising
- There are a few ways of achieving this but think something important is here
- If you were to take the negative feedback out of model 1 for instance, the 2nd player would dominate and model 1 would work out attack attack attack, even though it use to
3. This also seems to work when you just use the same network. Not two competing networks. But as player 1 always goes first i think its cool that player 1 learns a strategy for always going first and player 2 learns a strategy for always going second. 

What next:
Whilst it looks to learn something that produces a proper game, i haven't played it myself, or train using the AI game and then tried to play against it (cant save)
- Also not sure how you would play against 2 trained AI. Maybe if the user goes first it players the network trained to go second (model 2) and vice versa  
